### PR TITLE
Add warning about installing extension in JupyterLab

### DIFF
--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -87,7 +87,7 @@ if (buffers.length > 0) {{
 }}
 
 const comm_msg = receiver.message;
-if (comm_msg != null) {{
+if ((comm_msg != null) && (Object.keys(comm_msg.content).length > 0)) {{
   plot.model.document.apply_json_patch(comm_msg.content, comm_msg.buffers)
 }}
 """
@@ -100,7 +100,11 @@ if (!(document.getElementById('{plot_id}')) && !(document.getElementById('_anim_
   htmlObject.innerHTML = `{html}`;
   var scriptTags = document.getElementsByTagName('script');
   var parentTag = scriptTags[scriptTags.length-1].parentNode;
-  parentTag.append(htmlObject)
+  if (parentTag.attributes.length && (parentTag.attributes[0].name == 'data-shell-mode')) {{
+    alert('Displaying PyViz objects in JupyterLab requires the jupyterlab_pyviz extension to be installed, install it with:\\n\\n\\tjupyter labextension install @pyviz/jupyterlab_pyviz');
+  }} else {{
+    parentTag.append(htmlObject)
+  }}
 }}
 """
 


### PR DESCRIPTION
Avoids issues like this:

https://stackoverflow.com/questions/53536108/holoviews-plot-not-closing/53539047#53539047

![websj](https://user-images.githubusercontent.com/1550771/49224702-fe9db000-f3d9-11e8-8865-01c5dc0cd99e.png)

By adding an alert which warns JupyterLab users to install the extension:

![screen shot 2018-11-29 at 1 24 50 pm](https://user-images.githubusercontent.com/1550771/49224771-2db42180-f3da-11e8-8553-d70eb83ad0d6.png)

