### PR TITLE
Small fix to handling notebook output

### DIFF
--- a/pyviz_comms/notebook.js
+++ b/pyviz_comms/notebook.js
@@ -19,7 +19,7 @@ function render(props, node) {
 function handle_add_output(event, handle) {
   var output_area = handle.output_area;
   var output = handle.output;
-  if (!output.data.hasOwnProperty(EXEC_MIME_TYPE)) {
+  if ((output.data == undefined) || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
     return
   }
   var id = output.metadata[EXEC_MIME_TYPE]["id"];


### PR DESCRIPTION
Gets rid of these errors in classic notebook:

```
events.js:33 Exception in event handler for output_added.OutputArea TypeError: Cannot read property 'hasOwnProperty' of undefined
    at window._Events.handle_add_output (eval at append_javascript (outputarea.js:761), <anonymous>:75:21)
    at window._Events.dispatch (jquery.min.js:3)
    at window._Events.r.handle (jquery.min.js:3)
    at Object.trigger (jquery.min.js:4)
    at window._Events.<anonymous> (jquery.min.js:4)
    at Function.each (jquery.min.js:2)
    at n.fn.init.each (jquery.min.js:2)
    at n.fn.init.trigger (jquery.min.js:4)
    at n.fn.init.events.trigger (events.js:31)
    at OutputArea.append_output (outputarea.js:355) Arguments(2) ["output_added.OutputArea", {…}, callee: (...), Symbol(Symbol.iterator): ƒ]
```