### PR TITLE
Only send cleanup message if kernel is unchanged

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -86,6 +86,7 @@ class HVJSExec extends Widget implements IRenderMime.IRenderer {
   private _js_mimetype: string = JS_MIME_TYPE
   // the metadata is stored here
   private _document_id: string
+  private _kernel_id: string
   private _exec_mimetype: string = HV_EXEC_MIME_TYPE
   private _script_element: HTMLScriptElement
   private _div_element: HTMLDivElement
@@ -138,6 +139,8 @@ class HVJSExec extends Widget implements IRenderMime.IRenderer {
 
       const manager = this._manager;
       const kernel = manager.context.session.kernel;
+      if (kernel !== null)
+        this._kernel_id = kernel.id;
       const registerClosure = (targetName: string, callback: (comm: Kernel.IComm, msg: KernelMessage.ICommOpenMsg) => void): void => {
         if (kernel == undefined) {
           console.log('Kernel not found, could not register comm target ', targetName);
@@ -189,8 +192,9 @@ class HVJSExec extends Widget implements IRenderMime.IRenderer {
 
   _disposePlot(): void {
     const id = this._document_id;
+    const kernel = this._manager.context.session.kernel
     if (id !== null) {
-      if (this._manager.comm !== null) {
+      if ((this._manager.comm !== null) && (kernel.id === this._kernel_id)) {
         this._manager.comm.send({event_type: "delete", "id": id});
       }
       if (((window as any).PyViz !== undefined) && ((window as any).PyViz.kernels !== undefined)) {


### PR DESCRIPTION
Since we are using the root model id for identifying a plot and bokeh switched to counter based ids this had the unfortunate side-effect that in many cases rerunning the first cell with a plot in it using a new kernel would immediately trigger a cleanup message to that very same plot to be sent. This PR ensures that the cleanup message is only sent if the kernel id is unchanged since the plot was rendered.