### PR TITLE
Ensure that DOM nodes do not override global PyViz object

### DIFF
--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -59,8 +59,8 @@ class extension(param.ParameterizedFunction):
 
 
 PYVIZ_PROXY = """
-if (window.PyViz === undefined) {
-   if (window.HoloViews === undefined) {
+if ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {
+   if ((window.HoloViews === undefined) || (window.HoloViews instanceof HTMLElement)) {
      var PyViz = {comms: {}, comm_status:{}, kernels:{}, receivers: {}, plot_index: []}
    } else {
      var PyViz = window.HoloViews;


### PR DESCRIPTION
A really stupid bug meant that if there was a header tag in a JupyterLab notebook it would end up being added to window.HoloViews and alias it to windows.PyViz, this makes sure these variables are overridden if they reference DOM nodes.