### PR TITLE
Ensure PyViz global is instantiated correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ installation may refer to the below table.
 | ------------- | ---------------- |
 | 0.33.x        | 0.6.0            |
 | 0.34.x        | 0.6.1-0.6.2      |
-| 0.35.x        | 0.6.3-0.7.1      |
+| 0.35.x        | 0.6.3-0.7.2      |
 
 ## Developing the Jupyterlab extension
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyviz/jupyterlab_pyviz",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A JupyterLab extension for rendering PyViz content",
   "author": "Philipp Rudiger <prudiger@anaconda.org>",
   "main": "lib/index.js",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -123,9 +123,8 @@ class HVJSExec extends Widget implements IRenderMime.IRenderer {
     }
     this._dispose = true;
     if (id !== undefined) {
-      // I'm a static document
       if ((window as any).PyViz === undefined) {
-        (window as any).PyViz = {kernels: {}, plot_index: {}};
+        (window as any).PyViz = {comms: {}, comm_status:{}, kernels:{}, receivers: {}, plot_index: []};
       } else if ((window as any).PyViz.plot_index === undefined) {
         (window as any).PyViz.plot_index = {}
       }


### PR DESCRIPTION
It seems in certain versions of JLab there is a race condition where the extension is not necessarily loaded by the time the first output is received. In this case the PyViz global object is not initialized correctly (because it was assumed that condition would only happen in exported notebooks), this PR ensures that it is fully populated ensuring that the race condition has no actual effect.